### PR TITLE
Context menu, separate settings from internals

### DIFF
--- a/@Resources/MonD.inc
+++ b/@Resources/MonD.inc
@@ -4,3 +4,8 @@ PreviewImage=https://repository-images.githubusercontent.com/667142052/9908a45b-
 Author=creepertron95
 ProfilePicture=https://avatars.githubusercontent.com/u/53346722
 Description=Enhanced Honeycomb
+
+Exclude=#Source Files
+Version=1.1.1
+HeaderImage=#@#Assets\banner.bmp
+VariableFiles=#@#config.inc

--- a/@Resources/Variants/base_default.inc
+++ b/@Resources/Variants/base_default.inc
@@ -5,7 +5,7 @@ ImageTint=#BaseColor#
 LeftMouseUpAction=#Action#
 H=#HoneycombSize#
 
-[Base Overlay]
+[BaseOverlay]
 Meter=Image
 ImageName=#@#Base\#BaseOverlay#
 ImageTint=#OverlayColor#

--- a/@Resources/Variants/base_default.inc
+++ b/@Resources/Variants/base_default.inc
@@ -7,7 +7,7 @@ H=#HoneycombSize#
 
 [Base Overlay]
 Meter=Image
-ImageName=#BaseOverlay#
+ImageName=#@#Base\#BaseOverlay#
 ImageTint=#OverlayColor#
 GreyScale=#IconGreyscale#
 H=#HoneycombSize#

--- a/@Resources/common.inc
+++ b/@Resources/common.inc
@@ -17,8 +17,8 @@ ContextAction4=[!SkinMenu]
 
 [Variables]
 ; Internal variables
-Blank=#@#\Base\blank.png
-Mono=#@#\Icons\#Type#\mono\#Icon#.png
-MonoName=#@#\Icons\#Type#\mono\#IconMonoName#.png
-Overlay=#@#\Icons\#Type#\overlay\#Icon#.png
-@IncludeBase=#@#Variants/base_#Base#.inc
+Blank=#@#Base\blank.png
+Mono=#@#Icons\#Type#\mono\#Icon#.png
+MonoName=#@#Icons\#Type#\mono\#IconMonoName#.png
+Overlay=#@#Icons\#Type#\overlay\#Icon#.png
+@IncludeBase=#@#Variants\base_#Base#.inc

--- a/@Resources/common.inc
+++ b/@Resources/common.inc
@@ -3,14 +3,18 @@ Update=-1
 Group=HoneycombNG
 RightMouseUpAction=[!SkinCustomMenu]
 
-ContextTitle=Edit config
-ContextAction=["#CONFIGEDITOR#" "#@#config.inc"]
-ContextTitle2=Refresh HoneycombNG
-ContextAction2=[!RefreshGroup HoneycombNG]
-ContextTitle3=-
-ContextAction3=
-ContextTitle4=Open skin menu
-ContextAction4=[!SkinMenu]
+ContextTitle=#CURRENTCONFIG#
+ContextAction=["#CURRENTPATH#"]
+ContextTitle2=-
+ContextAction2=
+ContextTitle3=Edit config
+ContextAction3=["#CONFIGEDITOR#" "#@#config.inc"]
+ContextTitle4=Refresh HoneycombNG
+ContextAction4=[!RefreshGroup HoneycombNG]
+ContextTitle5=-
+ContextAction5=
+ContextTitle6=Open skin menu
+ContextAction6=[!SkinMenu]
 
 [IncludeConfig]
 @IncludeConfig=#@#config.inc

--- a/@Resources/common.inc
+++ b/@Resources/common.inc
@@ -1,3 +1,14 @@
+[IncludeConfig]
+@IncludeConfig=#@#config.inc
+
+[Variables]
+; Internal variables
+Blank=#@#Base\blank.png
+Mono=#@#Icons\#Type#\mono\#Icon#.png
+MonoName=#@#Icons\#Type#\mono\#IconMonoName#.png
+Overlay=#@#Icons\#Type#\overlay\#Icon#.png
+@IncludeBase=#@#Variants\base_#Base#.inc
+
 [Rainmeter]
 Update=-1
 Group=HoneycombNG
@@ -15,14 +26,3 @@ ContextTitle5=-
 ContextAction5=
 ContextTitle6=Open skin menu
 ContextAction6=[!SkinMenu]
-
-[IncludeConfig]
-@IncludeConfig=#@#config.inc
-
-[Variables]
-; Internal variables
-Blank=#@#Base\blank.png
-Mono=#@#Icons\#Type#\mono\#Icon#.png
-MonoName=#@#Icons\#Type#\mono\#IconMonoName#.png
-Overlay=#@#Icons\#Type#\overlay\#Icon#.png
-@IncludeBase=#@#Variants\base_#Base#.inc

--- a/@Resources/common.inc
+++ b/@Resources/common.inc
@@ -1,0 +1,24 @@
+[Rainmeter]
+Update=-1
+Group=HoneycombNG
+RightMouseUpAction=[!SkinCustomMenu]
+
+ContextTitle=Edit config
+ContextAction=["#CONFIGEDITOR#" "#@#config.inc"]
+ContextTitle2=Refresh HoneycombNG
+ContextAction2=[!RefreshGroup HoneycombNG]
+ContextTitle3=-
+ContextAction3=
+ContextTitle4=Open skin menu
+ContextAction4=[!SkinMenu]
+
+[IncludeConfig]
+@IncludeConfig=#@#config.inc
+
+[Variables]
+; Internal variables
+Blank=#@#\Base\blank.png
+Mono=#@#\Icons\#Type#\mono\#Icon#.png
+MonoName=#@#\Icons\#Type#\mono\#IconMonoName#.png
+Overlay=#@#\Icons\#Type#\overlay\#Icon#.png
+@IncludeBase=#@#Variants/base_#Base#.inc

--- a/@Resources/config.inc
+++ b/@Resources/config.inc
@@ -1,22 +1,31 @@
 [Variables]
 
-;;Base Settings;;
-; default | clear | mono
-Base=default
-; none | cube | glazed | gloss | gradient | jelly | oldios | toon-grad | toon
-BaseStyle=none
+; After changing the variables, save the file (ctrl + S), 
+; right click any Honeycomb and choose "Refresh HoneycombNG"
+
 HoneycombSize=90
 
-;;Colors;;
+; Available bases:
+; default | clear | mono
+Base=default
+
+; Available base styles:
+; none | cube | glazed | gloss | gradient | jelly | oldios | toon-grad | toon
+BaseStyle=none
+
+; Available hover effects:
+; default | clear | none | rim
+Hover=default
+HoverColor=0, 0, 0, 125
+
+; Colors
+; Remove the ; to enable the override
+
 ;IconColor=76,86,106
 ;BaseColor=235,203,139
 ;ShadowColor=
 ;OverlayColor=
 ;ClearColor=
 
-;;Hover Settings;;
-Hover=default
-HoverColor=0, 0, 0, 125
-
-;;Misc Settings;;
+; Misc options
 ;IconGreyscale=

--- a/@Resources/config.inc
+++ b/@Resources/config.inc
@@ -1,7 +1,9 @@
 [Variables]
 
 ;;Base Settings;;
+; default | clear | mono
 Base=default
+; none | cube | glazed | gloss | gradient | jelly | oldios | toon-grad | toon
 BaseStyle=none
 HoneycombSize=90
 
@@ -18,13 +20,3 @@ HoverColor=0, 0, 0, 125
 
 ;;Misc Settings;;
 ;IconGreyscale=
-
-;;Other Variables;;
-Blank=#@#\Base\blank.png
-Mono=#@#\Icons\#Type#\mono\#Icon#.png
-MonoName=#@#\Icons\#Type#\mono\#IconMonoName#.png
-Overlay=#@#\Icons\#Type#\overlay\#Icon#.png
-@Include=#@#Variants/base_#Base#.inc
-
-[Rainmeter]
-Update=-1

--- a/Apps/0-9/0cc-famitracker/0cc-famitracker.ini
+++ b/Apps/0-9/0cc-famitracker/0cc-famitracker.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=0cc-famitracker
 Information=

--- a/Apps/0-9/3d-coat/3d-coat.ini
+++ b/Apps/0-9/3d-coat/3d-coat.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=3d-coat
 Information=

--- a/Apps/A/ableton-live/ableton-live.ini
+++ b/Apps/A/ableton-live/ableton-live.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ableton-live
 Information=

--- a/Apps/A/ac3d/ac3d.ini
+++ b/Apps/A/ac3d/ac3d.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ac3d
 Information=

--- a/Apps/A/adobe-audition/adobe-audition.ini
+++ b/Apps/A/adobe-audition/adobe-audition.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=adobe-audition
 Information=

--- a/Apps/A/adobe-photoshop/adobe-photoshop.ini
+++ b/Apps/A/adobe-photoshop/adobe-photoshop.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=adobe-photoshop
 Information=

--- a/Apps/A/adobe-premiere/adobe-premiere.ini
+++ b/Apps/A/adobe-premiere/adobe-premiere.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=adobe-premiere
 Information=

--- a/Apps/A/agama-materials/agama-materials.ini
+++ b/Apps/A/agama-materials/agama-materials.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=agama-materials
 Information=

--- a/Apps/A/amd/amd.ini
+++ b/Apps/A/amd/amd.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=amd
 Information=

--- a/Apps/A/ao-todo-app/ao-todo-app.ini
+++ b/Apps/A/ao-todo-app/ao-todo-app.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ao-todo-app
 Information=

--- a/Apps/A/apk-editor-studio/apk-editor-studio.ini
+++ b/Apps/A/apk-editor-studio/apk-editor-studio.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=apk-editor-studio
 Information=

--- a/Apps/A/apk-icon-editor/apk-icon-editor.ini
+++ b/Apps/A/apk-icon-editor/apk-icon-editor.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=apk-icon-editor
 Information=

--- a/Apps/A/artrage/artrage.ini
+++ b/Apps/A/artrage/artrage.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=artrage
 Information=

--- a/Apps/A/aseprite/aseprite.ini
+++ b/Apps/A/aseprite/aseprite.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=aseprite
 Information=

--- a/Apps/A/audacity/audacity.ini
+++ b/Apps/A/audacity/audacity.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=audacity
 Information=

--- a/Apps/A/avg/avg.ini
+++ b/Apps/A/avg/avg.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=236,239,244,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=avg
 Information=

--- a/Apps/B/bambootracker/bambootracker.ini
+++ b/Apps/B/bambootracker/bambootracker.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=163,190,140,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=bambootracker
 Information=

--- a/Apps/B/bc-uninstaller/bc-uninstaller.ini
+++ b/Apps/B/bc-uninstaller/bc-uninstaller.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=bc-uninstaller
 Information=

--- a/Apps/B/bforartists/bforartists.ini
+++ b/Apps/B/bforartists/bforartists.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=bforartists
 Information=

--- a/Apps/B/bitdefender/bitdefender.ini
+++ b/Apps/B/bitdefender/bitdefender.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=bitdefender
 Information=

--- a/Apps/B/bittorrent/bittorrent.ini
+++ b/Apps/B/bittorrent/bittorrent.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=bittorrent
 Information=

--- a/Apps/B/blender/blender.ini
+++ b/Apps/B/blender/blender.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=blender
 Information=

--- a/Apps/B/blockbench/blockbench.ini
+++ b/Apps/B/blockbench/blockbench.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=blockbench
 Information=

--- a/Apps/B/borderless-gaming/borderless-gaming.ini
+++ b/Apps/B/borderless-gaming/borderless-gaming.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=borderless-gaming
 Information=

--- a/Apps/B/bosca-ceoil/bosca-ceoil.ini
+++ b/Apps/B/bosca-ceoil/bosca-ceoil.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=126,158,191,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=bosca-ceoil
 Information=

--- a/Apps/B/brave/brave.ini
+++ b/Apps/B/brave/brave.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=brave
 Information=

--- a/Apps/C/calibre/calibre.ini
+++ b/Apps/C/calibre/calibre.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=224,200,156,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=calibre
 Information=

--- a/Apps/C/celaction-2d/celaction-2d.ini
+++ b/Apps/C/celaction-2d/celaction-2d.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=celaction-2d
 Information=

--- a/Apps/C/cinema-4d/cinema-4d.ini
+++ b/Apps/C/cinema-4d/cinema-4d.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=cinema-4d
 Information=

--- a/Apps/C/clover/clover.ini
+++ b/Apps/C/clover/clover.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=clover
 Information=

--- a/Apps/C/crocotile-3d/crocotile-3d.ini
+++ b/Apps/C/crocotile-3d/crocotile-3d.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=crocotile-3d
 Information=

--- a/Apps/C/cubase/cubase.ini
+++ b/Apps/C/cubase/cubase.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=cubase
 Information=

--- a/Apps/C/cupscale/cupscale.ini
+++ b/Apps/C/cupscale/cupscale.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=cupscale
 Information=

--- a/Apps/C/cursevoice/cursevoice.ini
+++ b/Apps/C/cursevoice/cursevoice.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=cursevoice
 Information=

--- a/Apps/D/daz-central/daz-central.ini
+++ b/Apps/D/daz-central/daz-central.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=108,142,180,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=daz-central
 Information=

--- a/Apps/D/daz-install-manager/daz-install-manager.ini
+++ b/Apps/D/daz-install-manager/daz-install-manager.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=daz-install-manager
 Information=

--- a/Apps/D/daz-studio/daz-studio.ini
+++ b/Apps/D/daz-studio/daz-studio.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=daz-studio
 Information=

--- a/Apps/D/deluge/deluge.ini
+++ b/Apps/D/deluge/deluge.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=deluge
 Information=

--- a/Apps/D/discord/discord.ini
+++ b/Apps/D/discord/discord.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=discord
 Information=

--- a/Apps/D/dropbox/dropbox.ini
+++ b/Apps/D/dropbox/dropbox.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=dropbox
 Information=

--- a/Apps/E/ebsynth/ebsynth.ini
+++ b/Apps/E/ebsynth/ebsynth.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ebsynth
 Information=

--- a/Apps/E/effekseer/effekseer.ini
+++ b/Apps/E/effekseer/effekseer.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=effekseer
 Information=

--- a/Apps/E/enve/enve.ini
+++ b/Apps/E/enve/enve.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=enve
 Information=

--- a/Apps/E/etcher/etcher.ini
+++ b/Apps/E/etcher/etcher.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=etcher
 Information=

--- a/Apps/E/evernote/evernote.ini
+++ b/Apps/E/evernote/evernote.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=evernote
 Information=

--- a/Apps/F/facerig/facerig.ini
+++ b/Apps/F/facerig/facerig.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=facerig
 Information=

--- a/Apps/F/famistudio/famistudio.ini
+++ b/Apps/F/famistudio/famistudio.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=216,222,233,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=famistudio
 Information=

--- a/Apps/F/famitracker/famitracker.ini
+++ b/Apps/F/famitracker/famitracker.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=famitracker
 Information=

--- a/Apps/F/fasttracker-2-clone/fasttracker-2-clone.ini
+++ b/Apps/F/fasttracker-2-clone/fasttracker-2-clone.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=fasttracker-2-clone
 Information=

--- a/Apps/F/firefox-developer/firefox-developer.ini
+++ b/Apps/F/firefox-developer/firefox-developer.ini
@@ -16,7 +16,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=firefox-developer
 Information=

--- a/Apps/F/firefox-nightly/firefox-nightly.ini
+++ b/Apps/F/firefox-nightly/firefox-nightly.ini
@@ -16,7 +16,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=firefox-nightly
 Information=

--- a/Apps/F/firefox/firefox.ini
+++ b/Apps/F/firefox/firefox.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=firefox
 Information=

--- a/Apps/F/fl-studio/fl-studio.ini
+++ b/Apps/F/fl-studio/fl-studio.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=240,164,81,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=fl-studio
 Information=

--- a/Apps/F/flowframes/flowframes.ini
+++ b/Apps/F/flowframes/flowframes.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=flowframes
 Information=

--- a/Apps/F/foobar2000/foobar2000.ini
+++ b/Apps/F/foobar2000/foobar2000.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=foobar2000
 Information=

--- a/Apps/F/fspy/fspy.ini
+++ b/Apps/F/fspy/fspy.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=110,203,115,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=fspy
 Information=

--- a/Apps/F/furnace-tracker/furnace-tracker.ini
+++ b/Apps/F/furnace-tracker/furnace-tracker.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=furnace-tracker
 Information=

--- a/Apps/G/geforce-experience/geforce-experience.ini
+++ b/Apps/G/geforce-experience/geforce-experience.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=geforce-experience
 Information=

--- a/Apps/G/gimp/gimp.ini
+++ b/Apps/G/gimp/gimp.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=gimp
 Information=

--- a/Apps/G/github-desktop/github-desktop.ini
+++ b/Apps/G/github-desktop/github-desktop.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=github-desktop
 Information=

--- a/Apps/G/google-chrome/chrome.ini
+++ b/Apps/G/google-chrome/chrome.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=chrome
 Information=

--- a/Apps/G/greenshot/greenshot.ini
+++ b/Apps/G/greenshot/greenshot.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=greenshot
 Information=

--- a/Apps/H/hamachi/hamachi.ini
+++ b/Apps/H/hamachi/hamachi.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=hamachi
 Information=

--- a/Apps/H/houdini/houdini.ini
+++ b/Apps/H/houdini/houdini.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=houdini
 Information=

--- a/Apps/I/inkscape/inkscape.ini
+++ b/Apps/I/inkscape/inkscape.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=inkscape
 Information=

--- a/Apps/I/inochi-creator/inochi-creator.ini
+++ b/Apps/I/inochi-creator/inochi-creator.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=inochi-creator
 Information=

--- a/Apps/I/inochi-session/inochi-session.ini
+++ b/Apps/I/inochi-session/inochi-session.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=239,137,118,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=inochi-session
 Information=

--- a/Apps/I/inochi2d/inochi2d.ini
+++ b/Apps/I/inochi2d/inochi2d.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=200,115,175,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=inochi2d
 Information=

--- a/Apps/J/jd-gui/jd-gui.ini
+++ b/Apps/J/jd-gui/jd-gui.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=jd-gui
 Information=

--- a/Apps/J/jetbrains-intellij/jetbrains-intellij.ini
+++ b/Apps/J/jetbrains-intellij/jetbrains-intellij.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=159,111,190,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=jetbrains-intellij
 Information=

--- a/Apps/K/kodi/kodi.ini
+++ b/Apps/K/kodi/kodi.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=kodi
 Information=

--- a/Apps/K/krita/krita.ini
+++ b/Apps/K/krita/krita.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=222,125,220,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=krita
 Information=

--- a/Apps/L/laigter/laigter.ini
+++ b/Apps/L/laigter/laigter.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=laigter
 Information=

--- a/Apps/L/ldtk/ldtk.ini
+++ b/Apps/L/ldtk/ldtk.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ldtk
 Information=

--- a/Apps/L/libresprite/libresprite.ini
+++ b/Apps/L/libresprite/libresprite.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=libresprite
 Information=

--- a/Apps/L/lightwave-3d/lightwave-3d.ini
+++ b/Apps/L/lightwave-3d/lightwave-3d.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=lightwave-3d
 Information=

--- a/Apps/L/lmms/lmms.ini
+++ b/Apps/L/lmms/lmms.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=lmms
 Information=

--- a/Apps/M/magicavoxel/magicavoxel.ini
+++ b/Apps/M/magicavoxel/magicavoxel.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=150,113,222,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=magicavoxel
 Information=

--- a/Apps/M/magix-movie-maker/magix-movie-maker.ini
+++ b/Apps/M/magix-movie-maker/magix-movie-maker.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=magix-movie-maker
 Information=

--- a/Apps/M/makehuman/makehuman.ini
+++ b/Apps/M/makehuman/makehuman.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=makehuman
 Information=

--- a/Apps/M/material-maker/material-maker.ini
+++ b/Apps/M/material-maker/material-maker.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=223,116,238,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=material-maker
 Information=

--- a/Apps/M/materialize/materialize.ini
+++ b/Apps/M/materialize/materialize.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=materialize
 Information=

--- a/Apps/M/maverick-model-3d/maverick-model-3d.ini
+++ b/Apps/M/maverick-model-3d/maverick-model-3d.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=255,112,112,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=maverick-model-3d
 Information=

--- a/Apps/M/mega/mega.ini
+++ b/Apps/M/mega/mega.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=mega
 Information=

--- a/Apps/M/miditrail/miditrail.ini
+++ b/Apps/M/miditrail/miditrail.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=miditrail
 Information=

--- a/Apps/M/mikumikumoving/mikumikumoving.ini
+++ b/Apps/M/mikumikumoving/mikumikumoving.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=mikumikumoving
 Information=

--- a/Apps/M/milkytracker/milkytracker.ini
+++ b/Apps/M/milkytracker/milkytracker.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=milkytracker
 Information=

--- a/Apps/M/minimeters/minimeters.ini
+++ b/Apps/M/minimeters/minimeters.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=minimeters
 Information=

--- a/Apps/M/moho/moho.ini
+++ b/Apps/M/moho/moho.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=moho
 Information=

--- a/Apps/M/ms-access/ms-access.ini
+++ b/Apps/M/ms-access/ms-access.ini
@@ -16,7 +16,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=215,95,151,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ms-access
 Information=

--- a/Apps/M/ms-excel/ms-excel.ini
+++ b/Apps/M/ms-excel/ms-excel.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=95,215,119,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ms-excel
 Information=

--- a/Apps/M/ms-notepad/ms-notepad.ini
+++ b/Apps/M/ms-notepad/ms-notepad.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ms-notepad
 Information=

--- a/Apps/M/ms-onenote/ms-onenote.ini
+++ b/Apps/M/ms-onenote/ms-onenote.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=182,95,215,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ms-onenote
 Information=

--- a/Apps/M/ms-outlook/ms-outlook.ini
+++ b/Apps/M/ms-outlook/ms-outlook.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ms-outlook
 Information=

--- a/Apps/M/ms-paint/ms-paint.ini
+++ b/Apps/M/ms-paint/ms-paint.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ms-paint
 Information=

--- a/Apps/M/ms-powerpoint/ms-powerpoint.ini
+++ b/Apps/M/ms-powerpoint/ms-powerpoint.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=215,95,95,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ms-powerpoint
 Information=

--- a/Apps/M/ms-publisher/ms-publisher.ini
+++ b/Apps/M/ms-publisher/ms-publisher.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=95,215,175,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ms-publisher
 Information=

--- a/Apps/M/ms-visual-studio-code/ms-visual-studio-code.ini
+++ b/Apps/M/ms-visual-studio-code/ms-visual-studio-code.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ms-visual-studio-code
 Information=

--- a/Apps/M/ms-visual-studio/ms-visual-studio.ini
+++ b/Apps/M/ms-visual-studio/ms-visual-studio.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ms-visual-studio
 Information=

--- a/Apps/M/ms-word/ms-word.ini
+++ b/Apps/M/ms-word/ms-word.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=66,105,178,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ms-word
 Information=

--- a/Apps/M/mumble/mumble.ini
+++ b/Apps/M/mumble/mumble.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=mumble
 Information=

--- a/Apps/N/ni-guitarrig/ni-guitarrig.ini
+++ b/Apps/N/ni-guitarrig/ni-guitarrig.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ni-guitarrig
 Information=

--- a/Apps/N/nomacs/nomacs.ini
+++ b/Apps/N/nomacs/nomacs.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=nomacs
 Information=

--- a/Apps/O/obs/obs.ini
+++ b/Apps/O/obs/obs.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=obs
 Information=

--- a/Apps/O/openmpt/openmpt.ini
+++ b/Apps/O/openmpt/openmpt.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=176,93,101,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=openmpt
 Information=

--- a/Apps/O/openshot/openshot.ini
+++ b/Apps/O/openshot/openshot.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=openshot
 Information=

--- a/Apps/O/opera-gx/opera-gx.ini
+++ b/Apps/O/opera-gx/opera-gx.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=opera-gx
 Information=

--- a/Apps/O/opera/opera.ini
+++ b/Apps/O/opera/opera.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=opera
 Information=

--- a/Apps/P/picocad/picocad.ini
+++ b/Apps/P/picocad/picocad.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=247,223,118,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=picocad
 Information=

--- a/Apps/P/pixel-composer/pixel-composer.ini
+++ b/Apps/P/pixel-composer/pixel-composer.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=pixel-composer
 Information=

--- a/Apps/P/pixelorama/pixelorama.ini
+++ b/Apps/P/pixelorama/pixelorama.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=pixelorama
 Information=

--- a/Apps/P/pixelover/pixelover.ini
+++ b/Apps/P/pixelover/pixelover.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=pixelover
 Information=

--- a/Apps/P/plex/plex.ini
+++ b/Apps/P/plex/plex.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=plex
 Information=

--- a/Apps/P/popcorn-time/popcorn-time.ini
+++ b/Apps/P/popcorn-time/popcorn-time.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=popcorn-time
 Information=

--- a/Apps/P/portableapps/portableapps.ini
+++ b/Apps/P/portableapps/portableapps.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=portableapps
 Information=

--- a/Apps/P/poser/poser.ini
+++ b/Apps/P/poser/poser.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=poser
 Information=

--- a/Apps/P/pureref/pureref.ini
+++ b/Apps/P/pureref/pureref.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=pureref
 Information=

--- a/Apps/R/r3ds-wrap/r3ds-wrap.ini
+++ b/Apps/R/r3ds-wrap/r3ds-wrap.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=r3ds-wrap
 Information=

--- a/Apps/R/raidcall/raidcall.ini
+++ b/Apps/R/raidcall/raidcall.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=raidcall
 Information=

--- a/Apps/R/rainmeter/rainmeter.ini
+++ b/Apps/R/rainmeter/rainmeter.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=rainmeter
 Information=

--- a/Apps/R/rebelle/rebelle.ini
+++ b/Apps/R/rebelle/rebelle.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=rebelle
 Information=

--- a/Apps/R/renpy/renpy.ini
+++ b/Apps/R/renpy/renpy.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=renpy
 Information=

--- a/Apps/R/reshade/reshade.ini
+++ b/Apps/R/reshade/reshade.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=110,164,211,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=reshade
 Information=

--- a/Apps/R/rocket-3f/rocket-3f.ini
+++ b/Apps/R/rocket-3f/rocket-3f.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=rocket-3f
 Information=

--- a/Apps/R/rosetta-stone/rosetta-stone.ini
+++ b/Apps/R/rosetta-stone/rosetta-stone.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=rosetta-stone
 Information=

--- a/Apps/S/sculptris/sculptris.ini
+++ b/Apps/S/sculptris/sculptris.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=sculptris
 Information=

--- a/Apps/S/skype/skype.ini
+++ b/Apps/S/skype/skype.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=skype
 Information=

--- a/Apps/S/speedfan/speedfan.ini
+++ b/Apps/S/speedfan/speedfan.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=speedfan
 Information=

--- a/Apps/S/spotify/spotify.ini
+++ b/Apps/S/spotify/spotify.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=rosetta-stone
 Information=

--- a/Apps/S/spriter-pro/spriter-pro.ini
+++ b/Apps/S/spriter-pro/spriter-pro.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=116,229,236,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=spriter-pro
 Information=

--- a/Apps/S/stencyl/stencyl.ini
+++ b/Apps/S/stencyl/stencyl.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=stencyl
 Information=

--- a/Apps/S/storyboarder/storyboarder.ini
+++ b/Apps/S/storyboarder/storyboarder.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=storyboarder
 Information=

--- a/Apps/S/sunvox/sunvox.ini
+++ b/Apps/S/sunvox/sunvox.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=sunvox
 Information=

--- a/Apps/S/synctoy/synctoy.ini
+++ b/Apps/S/synctoy/synctoy.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=synctoy
 Information=

--- a/Apps/S/synfig-studio/synfig-studio.ini
+++ b/Apps/S/synfig-studio/synfig-studio.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=synfig-studio
 Information=

--- a/Apps/T/tahoma2d/tahoma2d.ini
+++ b/Apps/T/tahoma2d/tahoma2d.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=tahoma2d
 Information=

--- a/Apps/T/teamspeak/teamspeak.ini
+++ b/Apps/T/teamspeak/teamspeak.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=teamspeak
 Information=

--- a/Apps/T/teamviewer/teamviewer.ini
+++ b/Apps/T/teamviewer/teamviewer.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=teamviewer
 Information=

--- a/Apps/T/ti-connect/ti-connect.ini
+++ b/Apps/T/ti-connect/ti-connect.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ti-connect
 Information=

--- a/Apps/T/tiled/tiled.ini
+++ b/Apps/T/tiled/tiled.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=tiled
 Information=

--- a/Apps/T/tor-browser-alpha/tor-browser-alpha.ini
+++ b/Apps/T/tor-browser-alpha/tor-browser-alpha.ini
@@ -16,7 +16,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=tor-browser-alpha
 Information=

--- a/Apps/T/tor-browser-nightly/tor-browser-nightly.ini
+++ b/Apps/T/tor-browser-nightly/tor-browser-nightly.ini
@@ -16,7 +16,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=tor-browser-nightly
 Information=

--- a/Apps/T/tor-browser/tor-browser.ini
+++ b/Apps/T/tor-browser/tor-browser.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=tor-browser
 Information=

--- a/Apps/T/tor/tor.ini
+++ b/Apps/T/tor/tor.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=tor
 Information=

--- a/Apps/T/transmission/transmission.ini
+++ b/Apps/T/transmission/transmission.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=transmission
 Information=

--- a/Apps/T/twitch/twitch.ini
+++ b/Apps/T/twitch/twitch.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=twitch
 Information=

--- a/Apps/U/utorrent/utorrent.ini
+++ b/Apps/U/utorrent/utorrent.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=utorrent
 Information=

--- a/Apps/V/ventrillo/ventrillo.ini
+++ b/Apps/V/ventrillo/ventrillo.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ventrillo
 Information=

--- a/Apps/V/virtualbox/virtualbox.ini
+++ b/Apps/V/virtualbox/virtualbox.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=virtualbox
 Information=

--- a/Apps/V/vital-synth/vital-synth.ini
+++ b/Apps/V/vital-synth/vital-synth.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=171,156,203,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=vital-synth
 Information=

--- a/Apps/V/vlc/vlc.ini
+++ b/Apps/V/vlc/vlc.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=vlc
 Information=

--- a/Apps/V/vroid-studio/vroid-studio.ini
+++ b/Apps/V/vroid-studio/vroid-studio.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=vroid-studio
 Information=

--- a/Apps/V/vuze/vuze.ini
+++ b/Apps/V/vuze/vuze.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=vuze
 Information=

--- a/Apps/W/winamp/winamp.ini
+++ b/Apps/W/winamp/winamp.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=winamp
 Information=

--- a/Apps/W/windirstat/windirstat.ini
+++ b/Apps/W/windirstat/windirstat.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=windirstat
 Information=

--- a/Apps/W/windows-media-center/windows-media-center.ini
+++ b/Apps/W/windows-media-center/windows-media-center.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=windows-media-center
 Information=

--- a/Apps/X/xbmc/xbmc.ini
+++ b/Apps/X/xbmc/xbmc.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=133,192,45,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=xbmc
 Information=

--- a/Apps/X/xnalara/xnalara.ini
+++ b/Apps/X/xnalara/xnalara.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=xnalara
 Information=

--- a/Apps/X/xsplit/xsplit.ini
+++ b/Apps/X/xsplit/xsplit.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=xsplit
 Information=

--- a/Apps/Y/youtube-dl/youtube-dl.ini
+++ b/Apps/Y/youtube-dl/youtube-dl.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=youtube-dl
 Information=

--- a/Apps/Z/zbrush/zbrush.ini
+++ b/Apps/Z/zbrush/zbrush.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=zbrush
 Information=

--- a/Games/0-9/0-ad/0-ad.ini
+++ b/Games/0-9/0-ad/0-ad.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=0-ad
 Information=

--- a/Games/0-9/140-game/140-game.ini
+++ b/Games/0-9/140-game/140-game.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=140-game
 Information=

--- a/Games/0-9/2048/2048.ini
+++ b/Games/0-9/2048/2048.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=2048
 Information=

--- a/Games/0-9/4d-toys/4d-toys.ini
+++ b/Games/0-9/4d-toys/4d-toys.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=94,129,172,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=4d-toys
 Information=

--- a/Games/0-9/6180-the-moon/6180-the-moon.ini
+++ b/Games/0-9/6180-the-moon/6180-the-moon.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=6180-the-moon
 Information=

--- a/Games/0-9/7-days-to-die/7-days-to-die.ini
+++ b/Games/0-9/7-days-to-die/7-days-to-die.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=7-days-to-die
 Information=

--- a/Games/A/aleph-one/aleph-one.ini
+++ b/Games/A/aleph-one/aleph-one.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=aleph-one
 Information=

--- a/Games/A/algodoo/algodoo.ini
+++ b/Games/A/algodoo/algodoo.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=algodoo
 Information=

--- a/Games/A/alien-arena/alien-arena.ini
+++ b/Games/A/alien-arena/alien-arena.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=alien-arena
 Information=

--- a/Games/A/altspace-vr/altspace-vr.ini
+++ b/Games/A/altspace-vr/altspace-vr.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=altspace-vr
 Information=

--- a/Games/A/and-yet-it-moves/and-yet-it-moves.ini
+++ b/Games/A/and-yet-it-moves/and-yet-it-moves.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=and-yet-it-moves
 Information=

--- a/Games/A/annalynn/annalynn.ini
+++ b/Games/A/annalynn/annalynn.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=annalynn
 Information=

--- a/Games/A/antichamber/antichamber.ini
+++ b/Games/A/antichamber/antichamber.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=antichamber
 Information=

--- a/Games/A/ares-emu/ares-emu.ini
+++ b/Games/A/ares-emu/ares-emu.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ares-emu
 Information=

--- a/Games/A/ark-survival-evolved/ark-survival-evolved.ini
+++ b/Games/A/ark-survival-evolved/ark-survival-evolved.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=158,177,214,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ark-survival-evolved
 Information=

--- a/Games/A/armagetron-advanced/armagetron-advanced.ini
+++ b/Games/A/armagetron-advanced/armagetron-advanced.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=armagetron-advanced
 Information=

--- a/Games/A/audica/audica.ini
+++ b/Games/A/audica/audica.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=208,135,112,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=audica
 Information=

--- a/Games/A/avgn-deluxe/avgn-deluxe.ini
+++ b/Games/A/avgn-deluxe/avgn-deluxe.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=avgn-deluxe
 Information=

--- a/Games/B/baba-is-you/baba-is-you.ini
+++ b/Games/B/baba-is-you/baba-is-you.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=baba-is-you
 Information=

--- a/Games/B/basilisk-ii/basilisk-ii.ini
+++ b/Games/B/basilisk-ii/basilisk-ii.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=basilisk-ii
 Information=

--- a/Games/B/battle-net/battle-net.ini
+++ b/Games/B/battle-net/battle-net.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=battle-net
 Information=

--- a/Games/B/beamng-drive/beamng-drive.ini
+++ b/Games/B/beamng-drive/beamng-drive.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=222,131,94,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=beamng-drive
 Information=

--- a/Games/B/besiege/besiege.ini
+++ b/Games/B/besiege/besiege.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=besiege
 Information=

--- a/Games/B/boombox-editor/boombox-editor.ini
+++ b/Games/B/boombox-editor/boombox-editor.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=boombox-editor
 Information=

--- a/Games/B/boombox/boombox.ini
+++ b/Games/B/boombox/boombox.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=boombox
 Information=

--- a/Games/B/borderlands-presequel/borderlands-presequel.ini
+++ b/Games/B/borderlands-presequel/borderlands-presequel.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=borderlands-presequel
 Information=

--- a/Games/B/borderlands/borderlands.ini
+++ b/Games/B/borderlands/borderlands.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=borderlands
 Information=

--- a/Games/B/bsnes/bsnes.ini
+++ b/Games/B/bsnes/bsnes.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=103,217,244,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=bsnes
 Information=

--- a/Games/B/bugdom/bugdom.ini
+++ b/Games/B/bugdom/bugdom.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=bugdom
 Information=

--- a/Games/B/byond/byond.ini
+++ b/Games/B/byond/byond.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=byond
 Information=

--- a/Games/C/cemu/cemu.ini
+++ b/Games/C/cemu/cemu.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=cemu
 Information=

--- a/Games/C/chilloutvr/chilloutvr.ini
+++ b/Games/C/chilloutvr/chilloutvr.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=chilloutvr
 Information=

--- a/Games/C/chuzzle/chuzzle.ini
+++ b/Games/C/chuzzle/chuzzle.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=chuzzle
 Information=

--- a/Games/C/citra/citra.ini
+++ b/Games/C/citra/citra.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=citra
 Information=

--- a/Games/C/civilization-v/civilization-v.ini
+++ b/Games/C/civilization-v/civilization-v.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=civilization-v
 Information=

--- a/Games/C/classicube/classicube.ini
+++ b/Games/C/classicube/classicube.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=classicube
 Information=

--- a/Games/C/counter-strike-go/counter-strike-go.ini
+++ b/Games/C/counter-strike-go/counter-strike-go.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=counter-strike-go
 Information=

--- a/Games/C/crazy-taxi/crazy-taxi.ini
+++ b/Games/C/crazy-taxi/crazy-taxi.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=crazy-taxi
 Information=

--- a/Games/C/cult-of-the-lamb/cult-of-the-lamb.ini
+++ b/Games/C/cult-of-the-lamb/cult-of-the-lamb.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=cult-of-the-lamb
 Information=

--- a/Games/C/cuphead/cuphead.ini
+++ b/Games/C/cuphead/cuphead.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=cuphead
 Information=

--- a/Games/D/darwinia/darwinia.ini
+++ b/Games/D/darwinia/darwinia.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=darwinia
 Information=

--- a/Games/D/ddnet/ddnet.ini
+++ b/Games/D/ddnet/ddnet.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ddnet
 Information=

--- a/Games/D/djmax-respect-v/djmax-respect-v.ini
+++ b/Games/D/djmax-respect-v/djmax-respect-v.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=djmax-respect-v
 Information=

--- a/Games/D/doki-doki-literature-club-plus/doki-doki-literature-club-plus.ini
+++ b/Games/D/doki-doki-literature-club-plus/doki-doki-literature-club-plus.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=doki-doki-literature-club-plus
 Information=

--- a/Games/D/doki-doki-literature-club/doki-doki-literature-club.ini
+++ b/Games/D/doki-doki-literature-club/doki-doki-literature-club.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=doki-doki-literature-club
 Information=

--- a/Games/D/doki-doki-mod-docker/doki-doki-mod-docker.ini
+++ b/Games/D/doki-doki-mod-docker/doki-doki-mod-docker.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=210,145,231,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=doki-doki-mod-docker
 Information=

--- a/Games/D/dolphin-emu/dolphin-emu.ini
+++ b/Games/D/dolphin-emu/dolphin-emu.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=dolphin-emu
 Information=

--- a/Games/D/dosbox-staging/dosbox-staging.ini
+++ b/Games/D/dosbox-staging/dosbox-staging.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=129,161,193,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=dosbox-staging
 Information=

--- a/Games/D/dosbox-x/dosbox-x.ini
+++ b/Games/D/dosbox-x/dosbox-x.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=dosbox-x
 Information=

--- a/Games/D/dosbox/dosbox.ini
+++ b/Games/D/dosbox/dosbox.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=dosbox
 Information=

--- a/Games/D/dota-2/dota-2.ini
+++ b/Games/D/dota-2/dota-2.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=dota-2
 Information=

--- a/Games/D/downwell/downwell.ini
+++ b/Games/D/downwell/downwell.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=downwell
 Information=

--- a/Games/D/duckstation/duckstation.ini
+++ b/Games/D/duckstation/duckstation.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=duckstation
 Information=

--- a/Games/E/ea-desktop/ea-desktop.ini
+++ b/Games/E/ea-desktop/ea-desktop.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ea-desktop
 Information=

--- a/Games/E/epic-games-launcher/epic-games-launcher.ini
+++ b/Games/E/epic-games-launcher/epic-games-launcher.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=epic-games-launcher
 Information=

--- a/Games/E/etterna/etterna.ini
+++ b/Games/E/etterna/etterna.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=etterna
 Information=

--- a/Games/F/fairy-tail/fairy-tail.ini
+++ b/Games/F/fairy-tail/fairy-tail.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=fairy-tail
 Information=

--- a/Games/F/fall-guys/fall-guys.ini
+++ b/Games/F/fall-guys/fall-guys.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=fall-guys
 Information=

--- a/Games/F/fighter-factory/fighter-factory.ini
+++ b/Games/F/fighter-factory/fighter-factory.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=74,124,227,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=fighter-factory
 Information=

--- a/Games/F/flycast/flycast.ini
+++ b/Games/F/flycast/flycast.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=flycast
 Information=

--- a/Games/F/fun-with-ragdolls/fun-with-ragdolls.ini
+++ b/Games/F/fun-with-ragdolls/fun-with-ragdolls.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=fun-with-ragdolls
 Information=

--- a/Games/F/future-client/future-client.ini
+++ b/Games/F/future-client/future-client.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=future-client
 Information=

--- a/Games/G/garrys-mod/garrys-mod.ini
+++ b/Games/G/garrys-mod/garrys-mod.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=garrys-mod
 Information=

--- a/Games/G/gish/gish.ini
+++ b/Games/G/gish/gish.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=gish
 Information=

--- a/Games/G/gog/gog.ini
+++ b/Games/G/gog/gog.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=gog
 Information=

--- a/Games/G/guild-wars-2/guild-wars-2.ini
+++ b/Games/G/guild-wars-2/guild-wars-2.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=guild-wars-2
 Information=

--- a/Games/H/half-life-alyx/half-life-alyx.ini
+++ b/Games/H/half-life-alyx/half-life-alyx.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=half-life-alyx
 Information=

--- a/Games/H/half-life-blue-shift/half-life-blue-shift.ini
+++ b/Games/H/half-life-blue-shift/half-life-blue-shift.ini
@@ -16,7 +16,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=half-life-blue-shift
 Information=

--- a/Games/H/half-life-decay/half-life-decay.ini
+++ b/Games/H/half-life-decay/half-life-decay.ini
@@ -16,7 +16,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=half-life-decay
 Information=

--- a/Games/H/half-life-opposing-force/half-life-opposing-force.ini
+++ b/Games/H/half-life-opposing-force/half-life-opposing-force.ini
@@ -16,7 +16,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=half-life-opposing-force
 Information=

--- a/Games/H/half-life/half-life.ini
+++ b/Games/H/half-life/half-life.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=half-life
 Information=

--- a/Games/H/hearthstone/hearthstone.ini
+++ b/Games/H/hearthstone/hearthstone.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=hearthstone
 Information=

--- a/Games/H/helios/helios.ini
+++ b/Games/H/helios/helios.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=helios
 Information=

--- a/Games/H/hitman-blood-money/hitman-blood-money.ini
+++ b/Games/H/hitman-blood-money/hitman-blood-money.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=hitman-blood-money
 Information=

--- a/Games/I/impact-client/impact-client.ini
+++ b/Games/I/impact-client/impact-client.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=197,141,184,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=impact-client
 Information=

--- a/Games/I/ishiiruka/ishiiruka.ini
+++ b/Games/I/ishiiruka/ishiiruka.ini
@@ -16,7 +16,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ishiiruka
 Information=

--- a/Games/K/kega-fusion/kega-fusion.ini
+++ b/Games/K/kega-fusion/kega-fusion.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=94,129,172,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=kega-fusion
 Information=

--- a/Games/K/kill-la-kill-if/kill-la-kill-if.ini
+++ b/Games/K/kill-la-kill-if/kill-la-kill-if.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=191,97,106,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=kill-la-kill-if
 Information=

--- a/Games/K/koboldai/koboldai.ini
+++ b/Games/K/koboldai/koboldai.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=koboldai
 Information=

--- a/Games/K/kongfusion/kongfusion.ini
+++ b/Games/K/kongfusion/kongfusion.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=kongfusion
 Information=

--- a/Games/L/league-of-legends/league-of-legends.ini
+++ b/Games/L/league-of-legends/league-of-legends.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=league-of-legends
 Information=

--- a/Games/L/lovely-planet/lovely-planet.ini
+++ b/Games/L/lovely-planet/lovely-planet.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=129,161,193,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=lovely-planet
 Information=

--- a/Games/L/lsd-revamped/lsd-revamped.ini
+++ b/Games/L/lsd-revamped/lsd-revamped.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=lsd-revamped
 Information=

--- a/Games/M/marathon-2/marathon-2.ini
+++ b/Games/M/marathon-2/marathon-2.ini
@@ -16,7 +16,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=marathon-2
 Information=

--- a/Games/M/marathon-infinity/marathon-infinity.ini
+++ b/Games/M/marathon-infinity/marathon-infinity.ini
@@ -16,7 +16,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=marathon-infinity
 Information=

--- a/Games/M/marathon/marathon.ini
+++ b/Games/M/marathon/marathon.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=marathon
 Information=

--- a/Games/M/marble-blast-gold/marble-blast-gold.ini
+++ b/Games/M/marble-blast-gold/marble-blast-gold.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=marble-blast-gold
 Information=

--- a/Games/M/megazeux/megazeux.ini
+++ b/Games/M/megazeux/megazeux.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=megazeux
 Information=

--- a/Games/M/melonds/melonds.ini
+++ b/Games/M/melonds/melonds.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=melonds
 Information=

--- a/Games/M/minecraft-dungeons/minecraft-dungeons.ini
+++ b/Games/M/minecraft-dungeons/minecraft-dungeons.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=minecraft-dungeons
 Information=

--- a/Games/M/minecraft-legends/minecraft-legends.ini
+++ b/Games/M/minecraft-legends/minecraft-legends.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=minecraft-legends
 Information=

--- a/Games/M/minecraft/minecraft.ini
+++ b/Games/M/minecraft/minecraft.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=minecraft
 Information=

--- a/Games/M/mini-vmac-128k/mini-vmac-128k.ini
+++ b/Games/M/mini-vmac-128k/mini-vmac-128k.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=mini-vmac-128k
 Information=

--- a/Games/M/mini-vmac-ii/mini-vmac-ii.ini
+++ b/Games/M/mini-vmac-ii/mini-vmac-ii.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=mini-vmac-ii
 Information=

--- a/Games/M/mini-vmac/mini-vmac.ini
+++ b/Games/M/mini-vmac/mini-vmac.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=mini-vmac
 Information=

--- a/Games/M/mirrors-edge/mirrors-edge.ini
+++ b/Games/M/mirrors-edge/mirrors-edge.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=mirrors-edge
 Information=

--- a/Games/M/mod-organizer-2/mod-organizer-2.ini
+++ b/Games/M/mod-organizer-2/mod-organizer-2.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=mod-organizer-2
 Information=

--- a/Games/M/monika-after-story/monika-after-story.ini
+++ b/Games/M/monika-after-story/monika-after-story.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=monika-after-story
 Information=

--- a/Games/M/multimc/multimc.ini
+++ b/Games/M/multimc/multimc.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=multimc
 Information=

--- a/Games/M/multiversus/multiversus.ini
+++ b/Games/M/multiversus/multiversus.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=multiversus
 Information=

--- a/Games/M/multiwinia/multiwinia.ini
+++ b/Games/M/multiwinia/multiwinia.ini
@@ -16,7 +16,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=darwinia
 Information=

--- a/Games/M/mupen64-plus/mupen64-plus.ini
+++ b/Games/M/mupen64-plus/mupen64-plus.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=mupen64-plus
 Information=

--- a/Games/N/neos-vr/neos-vr.ini
+++ b/Games/N/neos-vr/neos-vr.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=neos-vr
 Information=

--- a/Games/N/neverball/neverball.ini
+++ b/Games/N/neverball/neverball.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=neverball
 Information=

--- a/Games/N/neverputt/neverputt.ini
+++ b/Games/N/neverputt/neverputt.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=neverputt
 Information=

--- a/Games/O/origin/origin.ini
+++ b/Games/O/origin/origin.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=origin
 Information=

--- a/Games/O/osu/osu.ini
+++ b/Games/O/osu/osu.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=osu
 Information=

--- a/Games/P/papers-please/papers-please.ini
+++ b/Games/P/papers-please/papers-please.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=191,97,106,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=papers-please
 Information=

--- a/Games/P/pcsx2/pcsx2.ini
+++ b/Games/P/pcsx2/pcsx2.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=pcsx2
 Information=

--- a/Games/P/peggle-nights/peggle-nights.ini
+++ b/Games/P/peggle-nights/peggle-nights.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=peggle-nights
 Information=

--- a/Games/P/peggle/peggle.ini
+++ b/Games/P/peggle/peggle.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=peggle
 Information=

--- a/Games/P/pico-8/pico-8.ini
+++ b/Games/P/pico-8/pico-8.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=253,203,167,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=pico-8
 Information=

--- a/Games/P/pizza-tower/pizza-tower.ini
+++ b/Games/P/pizza-tower/pizza-tower.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=pizza-tower
 Information=

--- a/Games/P/plants-vs-zombies/plants-vs-zombies.ini
+++ b/Games/P/plants-vs-zombies/plants-vs-zombies.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=plants-vs-zombies
 Information=

--- a/Games/P/play-emu/play-emu.ini
+++ b/Games/P/play-emu/play-emu.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=play-emu
 Information=

--- a/Games/P/polymc/polymc.ini
+++ b/Games/P/polymc/polymc.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=polymc
 Information=

--- a/Games/P/prism-launcher/prism-launcher.ini
+++ b/Games/P/prism-launcher/prism-launcher.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=153,205,97,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=prism-launcher
 Information=

--- a/Games/P/project-heartbeat/project-heartbeat.ini
+++ b/Games/P/project-heartbeat/project-heartbeat.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=project-heartbeat
 Information=

--- a/Games/P/project-outfox/project-outfox.ini
+++ b/Games/P/project-outfox/project-outfox.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=project-outfox
 Information=

--- a/Games/Q/quaver/quaver.ini
+++ b/Games/Q/quaver/quaver.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=116,224,241,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=quaver
 Information=

--- a/Games/R/reicast/reicast.ini
+++ b/Games/R/reicast/reicast.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=reicast
 Information=

--- a/Games/R/residualvm/residualvm.ini
+++ b/Games/R/residualvm/residualvm.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=residualvm
 Information=

--- a/Games/R/retroarch/retroarch.ini
+++ b/Games/R/retroarch/retroarch.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=retroarch
 Information=

--- a/Games/R/robocraft-2/robocraft-2.ini
+++ b/Games/R/robocraft-2/robocraft-2.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=245,164,92,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=robocraft-2
 Information=

--- a/Games/R/robocraft/robocraft.ini
+++ b/Games/R/robocraft/robocraft.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=95,158,210,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=robocraft
 Information=

--- a/Games/R/rocks-n-diamonds/rocks-n-diamonds.ini
+++ b/Games/R/rocks-n-diamonds/rocks-n-diamonds.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=rocks-n-diamonds
 Information=

--- a/Games/R/rocksmith-2014/rocksmith-2014.ini
+++ b/Games/R/rocksmith-2014/rocksmith-2014.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=rocksmith-2014
 Information=

--- a/Games/R/rocksmith/rocksmith.ini
+++ b/Games/R/rocksmith/rocksmith.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=rocksmith
 Information=

--- a/Games/R/rpcs3/rpcs3.ini
+++ b/Games/R/rpcs3/rpcs3.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=rpcs3
 Information=

--- a/Games/R/runescape/runescape.ini
+++ b/Games/R/runescape/runescape.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=205,157,100,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=runescape
 Information=

--- a/Games/S/scummvm/scummvm.ini
+++ b/Games/S/scummvm/scummvm.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=scummvm
 Information=

--- a/Games/S/senran-kagura-burst-re-newal/senran-kagura-burst-re-newal.ini
+++ b/Games/S/senran-kagura-burst-re-newal/senran-kagura-burst-re-newal.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=senran-kagura-burst-re-newal
 Information=

--- a/Games/S/senran-kagura-estival-versus/senran-kagura-estival-versus.ini
+++ b/Games/S/senran-kagura-estival-versus/senran-kagura-estival-versus.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=senran-kagura-estival-versus
 Information=

--- a/Games/S/shapez/shapez.ini
+++ b/Games/S/shapez/shapez.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=shapez
 Information=

--- a/Games/S/sheepshaver/sheepshaver.ini
+++ b/Games/S/sheepshaver/sheepshaver.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=sheepshaver
 Information=

--- a/Games/S/sims-4-studio/sims-4-studio.ini
+++ b/Games/S/sims-4-studio/sims-4-studio.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=129,161,193,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=sims-4-studio
 Information=

--- a/Games/S/slap-city/slap-city.ini
+++ b/Games/S/slap-city/slap-city.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=slap-city
 Information=

--- a/Games/S/smite/smite.ini
+++ b/Games/S/smite/smite.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=smite
 Information=

--- a/Games/S/space-channel-5-part-2/space-channel-5-part-2.ini
+++ b/Games/S/space-channel-5-part-2/space-channel-5-part-2.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=space-channel-5-part-2
 Information=

--- a/Games/S/space-channel-5-vr/space-channel-5-vr.ini
+++ b/Games/S/space-channel-5-vr/space-channel-5-vr.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=space-channel-5-vr
 Information=

--- a/Games/S/space-channel-5/space-channel-5.ini
+++ b/Games/S/space-channel-5/space-channel-5.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=space-channel-5
 Information=

--- a/Games/S/space-invaders-extreme/space-invaders-extreme.ini
+++ b/Games/S/space-invaders-extreme/space-invaders-extreme.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=107,220,204,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=space-invaders-extreme
 Information=

--- a/Games/S/spore-modapi-installer/spore-modapi-installer.ini
+++ b/Games/S/spore-modapi-installer/spore-modapi-installer.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=spore-modapi-installer
 Information=

--- a/Games/S/spore-modapi-uninstaller/spore-modapi-uninstaller.ini
+++ b/Games/S/spore-modapi-uninstaller/spore-modapi-uninstaller.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=spore-modapi-uninstaller
 Information=

--- a/Games/S/spore-modapi/spore-modapi.ini
+++ b/Games/S/spore-modapi/spore-modapi.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=spore-modapi
 Information=

--- a/Games/S/spore/spore.ini
+++ b/Games/S/spore/spore.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=spore
 Information=

--- a/Games/S/starcraft-2/starcraft-2.ini
+++ b/Games/S/starcraft-2/starcraft-2.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=starcraft-2
 Information=

--- a/Games/S/starcraft/starcraft.ini
+++ b/Games/S/starcraft/starcraft.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=starcraft
 Information=

--- a/Games/S/steam/steam.ini
+++ b/Games/S/steam/steam.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=steam
 Information=

--- a/Games/S/steamvr/steamvr.ini
+++ b/Games/S/steamvr/steamvr.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=steamvr
 Information=

--- a/Games/S/stepmania/stepmania.ini
+++ b/Games/S/stepmania/stepmania.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=stepmania
 Information=

--- a/Games/S/stick-fight-the-game/stick-fight-the-game.ini
+++ b/Games/S/stick-fight-the-game/stick-fight-the-game.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=227,96,96,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=stick-fight-the-game
 Information=

--- a/Games/S/super-meat-boy/super-meat-boy.ini
+++ b/Games/S/super-meat-boy/super-meat-boy.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=super-meat-boy
 Information=

--- a/Games/S/superfly/superfly.ini
+++ b/Games/S/superfly/superfly.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=superfly
 Information=

--- a/Games/S/synth-riders/synth-riders.ini
+++ b/Games/S/synth-riders/synth-riders.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=synth-riders
 Information=

--- a/Games/T/team-fortress-2/team-fortress-2.ini
+++ b/Games/T/team-fortress-2/team-fortress-2.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=team-fortress-2
 Information=

--- a/Games/T/team-fortress-classic/team-fortress-classic.ini
+++ b/Games/T/team-fortress-classic/team-fortress-classic.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=team-fortress-classic
 Information=

--- a/Games/T/teeworlds/teeworlds.ini
+++ b/Games/T/teeworlds/teeworlds.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=teeworlds
 Information=

--- a/Games/T/terratech/terratech.ini
+++ b/Games/T/terratech/terratech.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=terratech
 Information=

--- a/Games/T/tes-skyrim/tes-skyrim.ini
+++ b/Games/T/tes-skyrim/tes-skyrim.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=tes-skyrim
 Information=

--- a/Games/T/the-binding-of-isaac/the-binding-of-isaac.ini
+++ b/Games/T/the-binding-of-isaac/the-binding-of-isaac.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=the-binding-of-isaac
 Information=

--- a/Games/T/the-sims-2/the-sims-2.ini
+++ b/Games/T/the-sims-2/the-sims-2.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=the-sims-2
 Information=

--- a/Games/T/the-sims-3/the-sims-3.ini
+++ b/Games/T/the-sims-3/the-sims-3.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=the-sims-3
 Information=

--- a/Games/T/the-sims-4/the-sims-4.ini
+++ b/Games/T/the-sims-4/the-sims-4.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=the-sims-4
 Information=

--- a/Games/T/thomas-was-alone/thomas-was-alone.ini
+++ b/Games/T/thomas-was-alone/thomas-was-alone.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=239,157,101,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=thomas-was-alone
 Information=

--- a/Games/T/tic-80/tic-80.ini
+++ b/Games/T/tic-80/tic-80.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=tic-80
 Information=

--- a/Games/T/tlauncher/tlauncher.ini
+++ b/Games/T/tlauncher/tlauncher.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=tlauncher
 Information=

--- a/Games/T/trailmakers/trailmakers.ini
+++ b/Games/T/trailmakers/trailmakers.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=trailmakers
 Information=

--- a/Games/U/ultrakill/ultrakill.ini
+++ b/Games/U/ultrakill/ultrakill.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=ultrakill
 Information=

--- a/Games/U/unreal-tournament/unreal-tournament.ini
+++ b/Games/U/unreal-tournament/unreal-tournament.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=unreal-tournament
 Information=

--- a/Games/V/valorant/valorant.ini
+++ b/Games/V/valorant/valorant.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=valorant
 Information=

--- a/Games/V/vdrift/vdrift.ini
+++ b/Games/V/vdrift/vdrift.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=vdrift
 Information=

--- a/Games/V/viveport/viveport.ini
+++ b/Games/V/viveport/viveport.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=viveport
 Information=

--- a/Games/V/vrchat/vrchat.ini
+++ b/Games/V/vrchat/vrchat.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=vrchat
 Information=

--- a/Games/W/world-of-goo/world-of-goo.ini
+++ b/Games/W/world-of-goo/world-of-goo.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=world-of-goo
 Information=

--- a/Games/W/world-of-horror/world-of-horror.ini
+++ b/Games/W/world-of-horror/world-of-horror.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=world-of-horror
 Information=

--- a/Games/X/x-moto/x-moto.ini
+++ b/Games/X/x-moto/x-moto.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=x-moto
 Information=

--- a/Games/Z/zero-k/zero-k.ini
+++ b/Games/Z/zero-k/zero-k.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=zero-k
 Information=

--- a/Games/Z/zsnes/zsnes.ini
+++ b/Games/Z/zsnes/zsnes.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=94,129,172,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=zsnes
 Information=

--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 # HoneycombNG
+
 Enhanced version of Honeycomb with updated comb and icon designs, Larger selection of icons, Multi-layered recolorable icons, Multiple variants, and a hover effect.
 
 ![preview](https://github.com/creepertron95/HoneycombNG/assets/53346722/d0afc193-a4b7-4004-ab8f-def05931c2ab)
 
 ---
-## Note 
+
+## Note
 
 Some icons will require editing the `Action=` line in the icon skins to point to the program on your hard drive.
+
 ## Install
 
 [Rainmeter](https://www.rainmeter.net/) is required to install the skin.
 
 - Github: Latest Release can be found [here](https://github.com/creepertron95/HoneycombNG/releases)
 - MonD: Can also be installed in [MonD](https://github.com/meters-on-demand/cli) using `mond install creepertron95/HoneycombNG`
+
 ## Features
 
 - Updated designs
@@ -22,12 +26,15 @@ Some icons will require editing the `Action=` line in the icon skins to point to
 - Hover effect
 
 ## Requests
+
 Icons can be requested in the issues tab.
 
 ## Wiki
+
 The wiki can be found [here](https://github.com/creepertron95/HoneycombNG/wiki)
 
 ## Credits
+
 - Original [Honeycomb](https://www.deviantart.com/apiium/art/Honeycomb-467211707) skin by [APIIUM](https://www.deviantart.com/apiium)
 - Clear Variant based on [Clear Honeycomb](https://www.deviantart.com/bud1994/art/Clear-Honeycomb-3-25-830905496) by [bud1994](https://www.deviantart.com/bud1994)
 - RAM and CPU skin code used from Honeycomb

--- a/System/Base/folder/folder.ini
+++ b/System/Base/folder/folder.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=folder
 Information=

--- a/System/Base/folder/folder.ini
+++ b/System/Base/folder/folder.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=76,86,106,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/System/Base/game/game.ini
+++ b/System/Base/game/game.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=game
 Information=

--- a/System/Base/game/game.ini
+++ b/System/Base/game/game.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=76,86,106,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/System/Base/gameboy/gameboy.ini
+++ b/System/Base/gameboy/gameboy.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=94,117,162,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/System/Base/gameboy/gameboy.ini
+++ b/System/Base/gameboy/gameboy.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=gameboy
 Information=

--- a/System/Base/honeycomb-ng-config/honeycomb-ng-config.ini
+++ b/System/Base/honeycomb-ng-config/honeycomb-ng-config.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=235,203,139,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/System/Base/honeycomb-ng-config/honeycomb-ng-config.ini
+++ b/System/Base/honeycomb-ng-config/honeycomb-ng-config.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=honeycomb-ng
 Information=

--- a/System/Base/honeycomb-ng/honeycomb-ng.ini
+++ b/System/Base/honeycomb-ng/honeycomb-ng.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=235,203,139,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/System/Base/honeycomb-ng/honeycomb-ng.ini
+++ b/System/Base/honeycomb-ng/honeycomb-ng.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=honeycomb-ng
 Information=

--- a/System/Base/mouse/mouse.ini
+++ b/System/Base/mouse/mouse.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=94,117,162,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/System/Base/mouse/mouse.ini
+++ b/System/Base/mouse/mouse.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=mouse
 Information=

--- a/System/Base/music/music.ini
+++ b/System/Base/music/music.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=76,86,106,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/System/Base/music/music.ini
+++ b/System/Base/music/music.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=music
 Information=

--- a/System/Base/notepad/notepad.ini
+++ b/System/Base/notepad/notepad.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=92,162,157,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/System/Base/notepad/notepad.ini
+++ b/System/Base/notepad/notepad.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=notepad
 Information=

--- a/System/Base/settings/settings.ini
+++ b/System/Base/settings/settings.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=76,86,106,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/System/Base/settings/settings.ini
+++ b/System/Base/settings/settings.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=settings
 Information=

--- a/System/Meters/meter-cpu/meter-cpu.ini
+++ b/System/Meters/meter-cpu/meter-cpu.ini
@@ -7,7 +7,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=76,86,106,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/System/Meters/meter-cpu/meter-cpu.ini
+++ b/System/Meters/meter-cpu/meter-cpu.ini
@@ -28,24 +28,14 @@ MeasureName=MeasureCPU
 FontFace=Segoe UI
 FontSize=15
 FontColor=#IconColor#
-X=45
-Y=36
+X=(#HoneycombSize# / 2)
+Y=(#HoneycombSize# / 2)
 StringAlign=CenterCenter
 StringStyle=Bold
 AntiAlias=1
-Text=%1%
-
-[Title]
-Meter=String
-Text=CPU
-FontFace=Segoe UI
-FontSize=9
-StringStyle=Bold
-x=29
-y=48
-FontColor=#IconColor#
-AutoScale=1
-AntiAlias=1
+Text=%1%#CRLF#CPU
+InlinePattern=CPU
+InlineSetting=Size | 9
 
 [Metadata]
 Name=audition

--- a/System/Meters/meter-cpu/meter-cpu.ini
+++ b/System/Meters/meter-cpu/meter-cpu.ini
@@ -14,7 +14,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 
 [Rainmeter]
 Update=1000

--- a/System/Meters/meter-ram/meter-ram.ini
+++ b/System/Meters/meter-ram/meter-ram.ini
@@ -1,7 +1,3 @@
-[HoneycombNG]
-AccurateText=1
-DynamicWindowSize=1
-
 [Variables]
 
 Icon=blank
@@ -22,18 +18,6 @@ ClearColor=#IconColor#
 
 [Rainmeter]
 Update=1000
-
-[TITLE]
-Meter=String
-Text=RAM
-FontFace=Segoe UI
-FontSize=9
-StringStyle=Bold
-x=29
-y=48
-FontColor=#IconColor#
-AutoScale=1
-AntiAlias=1
 
 [MeasurePhysMemTotal]
 Measure=PhysicalMemory
@@ -61,9 +45,12 @@ AntiAlias=1
 StringStyle=Bold
 NumOfDecimals=1
 AutoScale=1
-Text="%3B"
-x=14
-y=28
+X=(#HoneycombSize# / 2)
+Y=(#HoneycombSize# / 2)
+StringAlign=CenterCenter
+Text=%3B#CRLF#RAM
+InlinePattern=RAM
+InlineSetting=Size | 9
 
 [Metadata]
 Name=audition

--- a/System/Meters/meter-ram/meter-ram.ini
+++ b/System/Meters/meter-ram/meter-ram.ini
@@ -18,7 +18,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 
 [Rainmeter]
 Update=1000

--- a/System/Meters/meter-ram/meter-ram.ini
+++ b/System/Meters/meter-ram/meter-ram.ini
@@ -11,7 +11,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=76,86,106,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/0-9/4chan/4chan.ini
+++ b/Web/0-9/4chan/4chan.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=77,130,79,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/0-9/4chan/4chan.ini
+++ b/Web/0-9/4chan/4chan.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=4chan
 Information=

--- a/Web/C/craiyon/craiyon.ini
+++ b/Web/C/craiyon/craiyon.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=220,136,83,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/C/craiyon/craiyon.ini
+++ b/Web/C/craiyon/craiyon.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=craiyon
 Information=

--- a/Web/C/crunchyroll/crunchyroll.ini
+++ b/Web/C/crunchyroll/crunchyroll.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=219,157,101,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/C/crunchyroll/crunchyroll.ini
+++ b/Web/C/crunchyroll/crunchyroll.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=crunchyroll
 Information=

--- a/Web/D/deviantart/deviantart.ini
+++ b/Web/D/deviantart/deviantart.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=76,86,106,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/D/deviantart/deviantart.ini
+++ b/Web/D/deviantart/deviantart.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=deviantart
 Information=

--- a/Web/F/facebook/facebook.ini
+++ b/Web/F/facebook/facebook.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=facebook
 Information=

--- a/Web/F/facebook/facebook.ini
+++ b/Web/F/facebook/facebook.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=83,120,193,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/G/github/github.ini
+++ b/Web/G/github/github.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=github
 Information=

--- a/Web/G/github/github.ini
+++ b/Web/G/github/github.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=76,86,106,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/I/imgur/imgur.ini
+++ b/Web/I/imgur/imgur.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=imgur
 Information=

--- a/Web/I/imgur/imgur.ini
+++ b/Web/I/imgur/imgur.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=92,212,169,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/J/jukeblocks/jukeblocks.ini
+++ b/Web/J/jukeblocks/jukeblocks.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=200,140,185,255
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=jukeblocks
 Information=

--- a/Web/J/jukeblocks/jukeblocks.ini
+++ b/Web/J/jukeblocks/jukeblocks.ini
@@ -8,7 +8,7 @@ IconMono=#Mono#
 IconGreyscale=0
 
 BaseColor=76,86,106,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/K/kaedim-3d/kaedim-3d.ini
+++ b/Web/K/kaedim-3d/kaedim-3d.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=kaedim-3d
 Information=

--- a/Web/K/kaedim-3d/kaedim-3d.ini
+++ b/Web/K/kaedim-3d/kaedim-3d.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=155,99,110,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/L/lospec/lospec.ini
+++ b/Web/L/lospec/lospec.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=lospec
 Information=

--- a/Web/L/lospec/lospec.ini
+++ b/Web/L/lospec/lospec.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=76,86,106,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/M/midjourney/midjourney.ini
+++ b/Web/M/midjourney/midjourney.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=midjourney
 Information=

--- a/Web/M/midjourney/midjourney.ini
+++ b/Web/M/midjourney/midjourney.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=236,239,244,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/P/pandora/pandora.ini
+++ b/Web/P/pandora/pandora.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=pandora
 Information=

--- a/Web/P/pandora/pandora.ini
+++ b/Web/P/pandora/pandora.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=236,239,244,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/R/rave-dj/rave-dj.ini
+++ b/Web/R/rave-dj/rave-dj.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#IconColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=rave-dj
 Information=

--- a/Web/R/rave-dj/rave-dj.ini
+++ b/Web/R/rave-dj/rave-dj.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=76,86,106,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/R/reddit/reddit.ini
+++ b/Web/R/reddit/reddit.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=240,107,59,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/R/reddit/reddit.ini
+++ b/Web/R/reddit/reddit.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=reddit
 Information=

--- a/Web/T/twitter/twitter.ini
+++ b/Web/T/twitter/twitter.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=twitter
 Information=

--- a/Web/T/twitter/twitter.ini
+++ b/Web/T/twitter/twitter.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=86,169,225,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0

--- a/Web/Y/youtube/youtube.ini
+++ b/Web/Y/youtube/youtube.ini
@@ -15,7 +15,7 @@ ShadowColor=255,255,255,0
 
 ClearColor=#BaseColor#
 
-@Include=#@#config.inc
+@IncludeCommon=#@#common.inc
 [Metadata]
 Name=youtube
 Information=

--- a/Web/Y/youtube/youtube.ini
+++ b/Web/Y/youtube/youtube.ini
@@ -8,7 +8,7 @@ IconMono=#Icon#
 IconGreyscale=0
 
 BaseColor=215,91,91,255
-BaseOverlay=#Blank#
+BaseOverlay=blank
 OverlayColor=
 
 ShadowColor=255,255,255,0


### PR DESCRIPTION
Changelog: 

- Made common.inc and moved internal (non user editable) variables to it
- Made every skin `@Include` common.inc instead of config.inc. 
  - common.inc `@Include`s both the base and config.inc
- Added packaging information to mond.inc. Can now use `mond package HoneycombNG` to package
- Fixed some skins using `BaseOverlay=#Blank#` when they should have been using `BaseOverlay=blank`
  - `#Blank#` is not used anywhere anymore, might want to remove it?
- Combined the string meters in meter-cpu and meter-ram and centered them properly
- Added "edit config" to the context menu for easier access to the config file
- Added explanations to the config.inc variables
- Added "refresh HoneycombNG" to the context menu to easily refresh all HoneycombNG skins after changing the config
- A couple miscellaneous fixes like the duplicate backslashes after `#@#` etc.